### PR TITLE
SPR-58 feat: 장바구니 페이지 마크업 1차 완성 및 공통 컴포넌트 분리

### DIFF
--- a/front/shoe-prima-frontend/index.html
+++ b/front/shoe-prima-frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <title>shoppingmall</title>
   </head>
   <body>

--- a/front/shoe-prima-frontend/src/components/cart/CartInfo.tsx
+++ b/front/shoe-prima-frontend/src/components/cart/CartInfo.tsx
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+import CheckBox from '../common/CheckBox';
+import Title from '../common/Title';
+
+interface CartInfoProps {
+  totalItems: number;
+  onSelectAll: () => void;
+  onRemoveSelected: () => void;
+  allSelected: boolean;
+}
+
+const CartInfo: React.FC<CartInfoProps> = ({
+  totalItems,
+  onSelectAll,
+  onRemoveSelected,
+  allSelected,
+}) => {
+  return (
+    <CartInfoBox>
+      <Title
+        mainTitleSize="28px"
+        mainTitle="장바구니"
+        subTitleSize="20px"
+        subTitle={`총 ${totalItems}개의 상품`}
+        gap="16px"
+        paddingBottom="32px"
+      />
+      <SelectBox>
+        <CheckAndTextBox>
+          <CheckBox checked={allSelected} onChange={onSelectAll} />
+          <TextBox>전체선택</TextBox>
+        </CheckAndTextBox>
+        <TextButton onClick={onRemoveSelected}>선택삭제</TextButton>
+      </SelectBox>
+    </CartInfoBox>
+  );
+};
+
+export default CartInfo;
+
+const CartInfoBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const SelectBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: var(--padding---mobile-padding, 20px)
+    var(--padding---mobile-padding, 20px);
+  border-bottom: 1px solid var(--color---lightgray300, #e5e5e5);
+`;
+
+const TextBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  font-family: Pretendard;
+  font-size: var(--font-size---label-font-size, 15px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: -0.15px;
+`;
+
+const TextButton = styled.button`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 0px;
+
+  border: none;
+  background-color: transparent;
+  color: var(--gray-500, var(--color---gray500, #808080));
+  font-feature-settings: 'calt' off;
+
+  /* body/body2/underline */
+  font-family: Pretendard;
+  font-size: var(--font-size---body2-font-size, 15px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: -0.15px;
+  text-decoration-line: underline;
+  cursor: pointer;
+`;
+
+const CheckAndTextBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+`;

--- a/front/shoe-prima-frontend/src/components/cart/CartList.tsx
+++ b/front/shoe-prima-frontend/src/components/cart/CartList.tsx
@@ -1,0 +1,158 @@
+import styled from 'styled-components';
+import CheckBox from '../common/CheckBox';
+import SubButton from '../common/SubButton';
+import Title from '../common/Title';
+import Counter from '../common/Counter';
+import IconButton from '../common/IconButton';
+
+interface CartListProps {
+  id: number;
+  onRemove: () => void;
+  onCheck: (id: number, isChecked: boolean) => void;
+  checked: boolean;
+}
+
+const CartList: React.FC<CartListProps> = ({
+  id,
+  onRemove,
+  onCheck,
+  checked,
+}) => {
+  const handleCheck = () => {
+    onCheck(id, !checked);
+  };
+
+  const CostCard: React.FC<{ text: string }> = ({ text }) => {
+    return (
+      <CostCardBox>
+        <TextBox>{text}원</TextBox> <SubButton content="바로구매" primary />
+      </CostCardBox>
+    );
+  };
+
+  return (
+    <CartListBox>
+      <CheckBoxArea className="desktop-only">
+        <CheckBox checked={checked} onChange={handleCheck} />
+      </CheckBoxArea>
+      <ProductArea>
+        <CheckBoxArea className="mobile-only">
+          <CheckBox checked={checked} onChange={handleCheck} />
+        </CheckBoxArea>
+        <ProductWrapper>
+          <CloseButton>
+            <IconButton iconName="close" onClick={onRemove} />
+          </CloseButton>
+          <ProductCard>
+            <ProductImg src="/src/assets/testImg1.png" />
+            <ProductInfo>
+              <Title
+                mainTitleSize="1.0625rem"
+                mainTitle="상품 이름"
+                subTitleSize="0.875rem"
+                subTitle="색 / 사이즈"
+                gap="0.375rem"
+                paddingBottom="0rem"
+              />
+              <Counter max={999} />
+            </ProductInfo>
+          </ProductCard>
+        </ProductWrapper>
+        <CostCard text="999,999" />
+      </ProductArea>
+    </CartListBox>
+  );
+};
+
+export default CartList;
+
+const CartListBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+`;
+
+const CheckBoxArea = styled.div`
+  display: flex;
+  padding: 1rem 1.25rem;
+  align-items: center;
+  align-self: stretch;
+
+  &.mobile-only {
+    display: none;
+
+    @media (max-width: 768px) {
+      display: flex;
+      align-self: flex-start;
+    }
+  }
+
+  &.desktop-only {
+    @media (max-width: 768px) {
+      display: none;
+    }
+  }
+`;
+
+const ProductArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+`;
+
+const ProductWrapper = styled.div`
+  position: relative;
+`;
+
+const ProductCard = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding: 1.75rem 1.25rem;
+  width: 100%;
+  gap: 1rem;
+
+  @media (max-width: 768px) {
+    padding: 1rem 0;
+  }
+`;
+
+const CloseButton = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+`;
+
+const CostCardBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  border-top: 1px solid var(--lightgray--300);
+  border-bottom: 1px solid var(--lightgray--300);
+  background: var(--lightgray--100);
+  padding: 1rem;
+`;
+
+const TextBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ProductImg = styled.img`
+  width: 7.5rem;
+`;
+
+const ProductInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+`;

--- a/front/shoe-prima-frontend/src/components/common/Button.tsx
+++ b/front/shoe-prima-frontend/src/components/common/Button.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 // content: 필수사항, 나머지: 선택사항

--- a/front/shoe-prima-frontend/src/components/common/CheckBox.tsx
+++ b/front/shoe-prima-frontend/src/components/common/CheckBox.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import IconButton from '../common/IconButton';
+
+interface CheckBoxProps {
+  checked?: boolean;
+  onChange?: () => void;
+}
+
+const CheckBox: React.FC<CheckBoxProps> = ({ checked = false, onChange }) => {
+  return (
+    <CheckBoxBox onClick={onChange}>
+      <HiddenCheckBox checked={checked} onChange={onChange} />
+      <IconButtonWrapper isChecked={checked}>
+        {checked && <IconButton iconName="check" iconColor="#fff" />}
+      </IconButtonWrapper>
+    </CheckBoxBox>
+  );
+};
+
+export default CheckBox;
+
+const CheckBoxBox = styled.div`
+  display: flex;
+  width: fit-content;
+  position: relative;
+`;
+
+const HiddenCheckBox = styled.input.attrs({ type: 'checkbox' })`
+  display: none;
+`;
+
+interface IconButtonWrapperProps {
+  isChecked: boolean;
+}
+
+const IconButtonWrapper = styled.div<IconButtonWrapperProps>`
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${({ isChecked }) =>
+    isChecked ? 'var(--black--900)' : 'var(--white--900)'};
+  border: 1px solid var(--black--900);
+  cursor: pointer;
+`;

--- a/front/shoe-prima-frontend/src/components/common/Counter.tsx
+++ b/front/shoe-prima-frontend/src/components/common/Counter.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import IconButton from '../common/IconButton';
+
+interface CounterProps {
+  max: number;
+}
+
+const Counter: React.FC<CounterProps> = ({ max }) => {
+  const [count, setCount] = useState(0);
+
+  const handleIncrease = (): void => {
+    if (count < max) {
+      setCount(count + 1);
+    }
+  };
+
+  const handleDecrease = (): void => {
+    if (count > 0) {
+      setCount(count - 1);
+    }
+  };
+
+  return (
+    <CounterBox>
+      <IconButtonWrapper>
+        <IconButton iconName="remove" onClick={handleDecrease} />
+      </IconButtonWrapper>
+      <CountDisplay>{count}</CountDisplay>
+      <IconButtonWrapper>
+        <IconButton iconName="add" onClick={handleIncrease} />
+      </IconButtonWrapper>
+    </CounterBox>
+  );
+};
+
+export default Counter;
+
+const CounterBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 108px;
+`;
+
+const CountDisplay = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 3rem;
+  height: 2rem;
+  padding: 0rem 0.5rem;
+  border-top: 1px solid var(--lightgray--300);
+  border-bottom: 1px solid var(--lightgray--300);
+  font-size: 15px;
+`;
+
+const IconButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--lightgray--300);
+  padding: 0.25rem;
+`;

--- a/front/shoe-prima-frontend/src/components/common/IconButton.tsx
+++ b/front/shoe-prima-frontend/src/components/common/IconButton.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+interface IconButtonProps {
+  iconName: string;
+  onClick?: () => void;
+  ariaLabel?: string;
+  iconColor?: string;
+}
+
+const IconButton: React.FC<IconButtonProps> = ({
+  iconName,
+  onClick,
+  ariaLabel,
+  iconColor,
+}) => {
+  return (
+    <StyledIconButton onClick={onClick} aria-label={ariaLabel}>
+      <span className="material-icons" style={{ color: iconColor }}>
+        {iconName}
+      </span>
+    </StyledIconButton>
+  );
+};
+
+export default IconButton;
+
+const StyledIconButton = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .material-icons {
+    font-size: 24px;
+  }
+
+  &:hover {
+    background-color: transparent;
+  }
+
+  &:active {
+    background-color: transparent;
+  }
+
+  &:focus {
+    outline: none;
+    background-color: transparent;
+  }
+`;

--- a/front/shoe-prima-frontend/src/components/common/Layout.tsx
+++ b/front/shoe-prima-frontend/src/components/common/Layout.tsx
@@ -29,4 +29,7 @@ const Pages = styled.div`
   width: 100%;
 
   padding: 2.5rem;
+  // @media (max-width: 768px) {
+  //   padding: 0rem;
+  // }
 `;

--- a/front/shoe-prima-frontend/src/components/common/SubButton.tsx
+++ b/front/shoe-prima-frontend/src/components/common/SubButton.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+interface ButtonProps {
+  content: string;
+  primary?: boolean;
+  outline?: boolean;
+}
+
+const SubButton: React.FC<ButtonProps> = ({ content, primary, outline }) => {
+  return (
+    <StyledButton $primary={primary} $outline={outline}>
+      {content}
+    </StyledButton>
+  );
+};
+
+export default SubButton;
+
+const StyledButton = styled.button<{
+  $primary?: boolean;
+  $outline?: boolean;
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 4.75rem;
+  height: 2rem;
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border: none;
+  font-family: Pretendard;
+  font-size: 0.9375rem;
+  cursor: pointer;
+
+  ${({ $primary }) =>
+    $primary &&
+    `
+    background-color: var(--black--900);
+  `}
+
+  ${({ $outline }) =>
+    $outline &&
+    `
+    background-color: var(--white--900);
+    color: var(--black--900);
+    border: 1px solid var(--lightgray--300);
+  `}
+`;

--- a/front/shoe-prima-frontend/src/components/common/Title.tsx
+++ b/front/shoe-prima-frontend/src/components/common/Title.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+interface TitleProps {
+  mainTitle: string;
+  subTitle?: string;
+  mainTitleSize?: string;
+  subTitleSize?: string;
+  gap?: string;
+  paddingBottom?: string;
+}
+
+const Title: React.FC<TitleProps> = ({
+  mainTitle,
+  subTitle,
+  mainTitleSize,
+  subTitleSize,
+  gap,
+  paddingBottom,
+}) => {
+  return (
+    <TitleBox gap={gap} paddingBottom={paddingBottom}>
+      <MainTitle size={mainTitleSize}>{mainTitle}</MainTitle>
+      {subTitle && <SubTitle size={subTitleSize}>{subTitle}</SubTitle>}
+    </TitleBox>
+  );
+};
+
+export default Title;
+
+interface BoxProps {
+  gap?: string;
+  paddingBottom?: string;
+}
+
+const TitleBox = styled.div<BoxProps>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${({ gap }) => gap || 'var(--font-size---body1-font-size, 16px)'};
+  padding-bottom: ${({ paddingBottom }) => paddingBottom || '2rem'};
+`;
+
+interface TextProps {
+  size?: string;
+}
+
+const MainTitle = styled.div<TextProps>`
+  display: flex;
+  flex-direction: row;
+  align-self: stretch;
+  font-family: Pretendard;
+  font-size: ${({ size }) => size || 'var(--font-size---title2-font-size)'};
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  letter-spacing: -0.28px;
+`;
+
+const SubTitle = styled.div<TextProps>`
+  display: flex;
+  flex-direction: row;
+  color: var(--gray-500, var(--color---gray500));
+  font-feature-settings: 'calt' off;
+  font-family: Pretendard;
+  font-size: ${({ size }) => size || 'var(--font-size---heading2-font-size)'};
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: -0.2px;
+`;

--- a/front/shoe-prima-frontend/src/pages/Cart.tsx
+++ b/front/shoe-prima-frontend/src/pages/Cart.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import CheckoutInfo from '../components/checkout/CheckoutInfo';
+import CartInfo from '../components/cart/CartInfo';
+import CartList from '../components/cart/CartList';
+
+const Cart: React.FC = () => {
+  const [cartLists, setCartLists] = useState([1, 2]);
+  const [checkedItems, setCheckedItems] = useState<number[]>([]);
+
+  const handleRemoveCartList = (id: number): void => {
+    setCartLists(cartLists.filter((cartListId) => cartListId !== id));
+    setCheckedItems(checkedItems.filter((itemId) => itemId !== id));
+  };
+
+  const handleCheck = (id: number, isChecked: boolean) => {
+    if (isChecked) {
+      setCheckedItems([...checkedItems, id]);
+    } else {
+      setCheckedItems(checkedItems.filter((itemId) => itemId !== id));
+    }
+  };
+
+  const handleSelectAll = () => {
+    if (checkedItems.length === cartLists.length) {
+      setCheckedItems([]);
+    } else {
+      setCheckedItems(cartLists);
+    }
+  };
+
+  const handleRemoveSelected = () => {
+    setCartLists(cartLists.filter((id) => !checkedItems.includes(id)));
+    setCheckedItems([]);
+  };
+
+  return (
+    <CartBox>
+      <CartListBox>
+        <CartInfo
+          totalItems={checkedItems.length}
+          onSelectAll={handleSelectAll}
+          onRemoveSelected={handleRemoveSelected}
+          allSelected={checkedItems.length === cartLists.length}
+        />
+        {cartLists.map((id) => (
+          <CartList
+            key={id}
+            id={id}
+            onRemove={() => handleRemoveCartList(id)}
+            onCheck={handleCheck}
+            checked={checkedItems.includes(id)}
+          />
+        ))}
+      </CartListBox>
+      <Divider />
+      <CheckoutInfo />
+    </CartBox>
+  );
+};
+
+export default Cart;
+
+const CartBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 2.5rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 0;
+  }
+`;
+
+const CartListBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const Divider = styled.div`
+  align-self: stretch;
+  width: 0.0625rem;
+  background: var(--lightgray--300);
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;

--- a/front/shoe-prima-frontend/src/routes/Router.tsx
+++ b/front/shoe-prima-frontend/src/routes/Router.tsx
@@ -6,6 +6,7 @@ import Home from '../pages/Home';
 import ProductDetail from '../pages/ProductDetail';
 import Products from '../pages/Products';
 import Failed from '../pages/Failed';
+import Cart from '../pages/Cart';
 
 const Router: () => JSX.Element = () => {
   return (
@@ -17,6 +18,7 @@ const Router: () => JSX.Element = () => {
             <Route path="/products" element={<Products />} />
             <Route path="/products/:productId" element={<ProductDetail />} />
             <Route path="/confirmed/:orderId" element={<Confirmed />} />
+            <Route path="/cart" element={<Cart />} />
             <Route path="/failed/:orderId" element={<Failed />} />
             <Route path="/checkout" element={<Checkout />} />
           </Route>


### PR DESCRIPTION
## 장바구니 페이지 마크업 1차 마무리
- 필요한 로직(ex. checked, delete ...)까지 일단 추가해놓았습니다.
- 마크업 하다보니 다른 페이지에서도 사용되는 공통 컴포넌트들이 많이 보여서 common에 만들어 보았습니다. 

## 공통 컴포넌트 분리 
- Button, SubButton, CheckBox, IconButton, Titile 정도 만들었는데 살펴 보시고 별로면 안 쓰셔도 괜찮습니다!!

## Material Icon
- MUI 대신 간단하게 가져다 쓸 수 있는 걸로 바꿔서 index.html에 필요한 link 박아두었습니다. 